### PR TITLE
Upgrade to Ruby 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,4 @@
 
 # 9/26/2015
 
-* Added ability to pass a `context` object when verifying user login, allowing to pass extra data such as HTTP request (e.g. subdomain) if needed [5a99dac8f83492d643c20719f2d911d27c933a68](https://github.com/identification-io/CASino/commit/5a99dac8f83492d643c20719f2d911d27c933a68)
+* Added ability to pass a `context` object when verifying user login, allowing to pass extra data such as HTTP request (e.g. subdomain) if needed [5a99dac8f83492d643c20719f2d911d27c933a68](https://github.com/identification-io/Casino/commit/5a99dac8f83492d643c20719f2d911d27c933a68)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# CASino [![Build Status](https://secure.travis-ci.org/rbCAS/CASino.png?branch=master)](https://travis-ci.org/rbCAS/CASino) [![Coverage Status](https://coveralls.io/repos/rbCAS/CASino/badge.png?branch=master)](https://coveralls.io/r/rbCAS/CASino?branch=master)
+# Casino [![Build Status](https://secure.travis-ci.org/rbCAS/Casino.png?branch=master)](https://travis-ci.org/rbCAS/Casino) [![Coverage Status](https://coveralls.io/repos/rbCAS/Casino/badge.png?branch=master)](https://coveralls.io/r/rbCAS/Casino?branch=master)
 
-CASino Rails Engine (used in CASinoApp).
+Casino Rails Engine (used in CasinoApp).
 
 It currently supports [CAS 1.0 and CAS 2.0](http://apereo.github.io/cas) as well as [CAS 3.1 Single Sign Out](https://wiki.jasig.org/display/CASUM/Single+Sign+Out).
 
@@ -21,4 +21,4 @@ And then running tests using `appraisal`:
 
 ## License
 
-CASino is released under the [MIT License](http://www.opensource.org/licenses/MIT). See LICENSE.txt for further details.
+Casino is released under the [MIT License](http://www.opensource.org/licenses/MIT). See LICENSE.txt for further details.

--- a/app/api/casino/api.rb
+++ b/app/api/casino/api.rb
@@ -1,7 +1,7 @@
 require 'grape'
 
-class CASino::API < Grape::API
+class Casino::API < Grape::API
   format :json
 
-  mount CASino::API::Resource::AuthTokenTickets
+  mount Casino::API::Resource::AuthTokenTickets
 end

--- a/app/api/casino/api.rb
+++ b/app/api/casino/api.rb
@@ -1,7 +1,7 @@
 require 'grape'
 
-class Casino::API < Grape::API
+class Casino::Api < Grape::API
   format :json
 
-  mount Casino::API::Resource::AuthTokenTickets
+  mount Casino::Api::Resource::AuthTokenTickets
 end

--- a/app/api/casino/api/entity/auth_token_ticket.rb
+++ b/app/api/casino/api/entity/auth_token_ticket.rb
@@ -1,5 +1,5 @@
 require 'grape-entity'
 
-class CASino::API::Entity::AuthTokenTicket < Grape::Entity
+class Casino::API::Entity::AuthTokenTicket < Grape::Entity
   expose :ticket
 end

--- a/app/api/casino/api/entity/auth_token_ticket.rb
+++ b/app/api/casino/api/entity/auth_token_ticket.rb
@@ -1,5 +1,5 @@
 require 'grape-entity'
 
-class Casino::API::Entity::AuthTokenTicket < Grape::Entity
+class Casino::Api::Entity::AuthTokenTicket < Grape::Entity
   expose :ticket
 end

--- a/app/api/casino/api/resource/auth_token_tickets.rb
+++ b/app/api/casino/api/resource/auth_token_tickets.rb
@@ -1,12 +1,12 @@
 require 'grape'
 
-class CASino::API::Resource::AuthTokenTickets < Grape::API
+class Casino::API::Resource::AuthTokenTickets < Grape::API
   resource :auth_token_tickets do
     desc 'Create an auth token ticket'
     post do
-      @ticket = CASino::AuthTokenTicket.create
+      @ticket = Casino::AuthTokenTicket.create
       Rails.logger.debug "Created auth token ticket '#{@ticket.ticket}'"
-      present @ticket, with: CASino::API::Entity::AuthTokenTicket
+      present @ticket, with: Casino::API::Entity::AuthTokenTicket
     end
   end
 end

--- a/app/api/casino/api/resource/auth_token_tickets.rb
+++ b/app/api/casino/api/resource/auth_token_tickets.rb
@@ -1,12 +1,12 @@
 require 'grape'
 
-class Casino::API::Resource::AuthTokenTickets < Grape::API
+class Casino::Api::Resource::AuthTokenTickets < Grape::API
   resource :auth_token_tickets do
     desc 'Create an auth token ticket'
     post do
       @ticket = Casino::AuthTokenTicket.create
       Rails.logger.debug "Created auth token ticket '#{@ticket.ticket}'"
-      present @ticket, with: Casino::API::Entity::AuthTokenTicket
+      present @ticket, with: Casino::Api::Entity::AuthTokenTicket
     end
   end
 end

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css

--- a/app/assets/javascripts/casino/application.js.erb
+++ b/app/assets/javascripts/casino/application.js.erb
@@ -1,10 +1,10 @@
 // Place all the behaviors and hooks related to the matching controller here.
 (function(win) {
-  if(!win.CASino) {
-    win.CASino = { baseUrl: '<%= CASino::Engine.routes.url_helpers.root_path %>' };
+  if(!win.Casino) {
+    win.Casino = { baseUrl: '<%= Casino::Engine.routes.url_helpers.root_path %>' };
   }
 
-  win.CASino.url = function(path) {
-    return win.CASino.baseUrl + path;
+  win.Casino.url = function(path) {
+    return win.Casino.baseUrl + path;
   }
 })(this);

--- a/app/assets/javascripts/casino/sessions.js
+++ b/app/assets/javascripts/casino/sessions.js
@@ -1,5 +1,5 @@
 (function(win, doc) {
-  var url = win.CASino.url('login'),
+  var url = win.Casino.url('login'),
       cookie_regex = /(^|;)\s*tgt=/,
       ready_bound = false;
 

--- a/app/authenticators/casino/static_authenticator.rb
+++ b/app/authenticators/casino/static_authenticator.rb
@@ -2,7 +2,7 @@ require 'casino/authenticator'
 
 # The static authenticator is just a simple example.
 # Never use this authenticator in a productive environment!
-class CASino::StaticAuthenticator < CASino::Authenticator
+class Casino::StaticAuthenticator < Casino::Authenticator
 
   # @param [Hash] options
   def initialize(options)

--- a/app/builders/casino/proxy_response_builder.rb
+++ b/app/builders/casino/proxy_response_builder.rb
@@ -1,6 +1,6 @@
 require 'builder'
 
-class CASino::ProxyResponseBuilder
+class Casino::ProxyResponseBuilder
   attr_reader :success, :options
 
   def initialize(success, options)

--- a/app/builders/casino/ticket_validation_response_builder.rb
+++ b/app/builders/casino/ticket_validation_response_builder.rb
@@ -1,6 +1,6 @@
 require 'builder'
 
-class CASino::TicketValidationResponseBuilder
+class Casino::TicketValidationResponseBuilder
   attr_reader :success, :options
 
   def initialize(success, options)
@@ -13,10 +13,10 @@ class CASino::TicketValidationResponseBuilder
     xml.cas :serviceResponse, 'xmlns:cas' => 'http://www.yale.edu/tp/cas' do |service_response|
       if success
         ticket = options[:ticket]
-        if ticket.is_a?(CASino::ProxyTicket)
+        if ticket.is_a?(Casino::ProxyTicket)
           proxies = []
           service_ticket = ticket
-          while service_ticket.is_a?(CASino::ProxyTicket)
+          while service_ticket.is_a?(Casino::ProxyTicket)
             proxy_granting_ticket = ticket.proxy_granting_ticket
             proxies << proxy_granting_ticket.pgt_url
             service_ticket = proxy_granting_ticket.granter
@@ -73,7 +73,7 @@ class CASino::TicketValidationResponseBuilder
         proxy_granting_ticket = options[:proxy_granting_ticket]
         authentication_success.cas :proxyGrantingTicket, proxy_granting_ticket.iou
       end
-      if ticket.is_a?(CASino::ProxyTicket)
+      if ticket.is_a?(Casino::ProxyTicket)
         authentication_success.cas :proxies do |proxies_container|
           proxies.each do |proxy|
             proxies_container.cas :proxy, proxy

--- a/app/controllers/casino/application_controller.rb
+++ b/app/controllers/casino/application_controller.rb
@@ -1,6 +1,6 @@
 require 'casino'
 
-class CASino::ApplicationController < ::ApplicationController
+class Casino::ApplicationController < ::ApplicationController
   include ApplicationHelper
 
   layout 'application'

--- a/app/controllers/casino/auth_tokens_controller.rb
+++ b/app/controllers/casino/auth_tokens_controller.rb
@@ -1,5 +1,5 @@
-class CASino::AuthTokensController < CASino::ApplicationController
-  include CASino::SessionsHelper
+class Casino::AuthTokensController < Casino::ApplicationController
+  include Casino::SessionsHelper
 
   def login
     validation_result = validation_service.validation_result
@@ -9,7 +9,7 @@ class CASino::AuthTokensController < CASino::ApplicationController
 
   private
   def validation_service
-    @validation_service ||= CASino::AuthTokenValidationService.new(auth_token, auth_token_signature)
+    @validation_service ||= Casino::AuthTokenValidationService.new(auth_token, auth_token_signature)
   end
 
   def redirect_to_login

--- a/app/controllers/casino/controller_concern.rb
+++ b/app/controllers/casino/controller_concern.rb
@@ -1,0 +1,3 @@
+module Casino::ControllerConcern
+  extend ActiveSupport::Concern
+end

--- a/app/controllers/casino/controller_concern/ticket_validator.rb
+++ b/app/controllers/casino/controller_concern/ticket_validator.rb
@@ -1,7 +1,7 @@
-module CASino::ControllerConcern::TicketValidator
+module Casino::ControllerConcern::TicketValidator
   extend ActiveSupport::Concern
-  include CASino::ServiceTicketProcessor
-  include CASino::ProxyGrantingTicketProcessor
+  include Casino::ServiceTicketProcessor
+  include Casino::ProxyGrantingTicketProcessor
 
   def validate_ticket(ticket)
     validation_result = validate_ticket_for_service(ticket, params[:service], renew: params[:renew])
@@ -17,7 +17,7 @@ module CASino::ControllerConcern::TicketValidator
   end
 
   def build_ticket_validation_response(success, options = {})
-    render xml: CASino::TicketValidationResponseBuilder.new(success, options).build
+    render xml: Casino::TicketValidationResponseBuilder.new(success, options).build
   end
 
   def ensure_service_ticket_parameters_present

--- a/app/controllers/casino/login_attempts_controller.rb
+++ b/app/controllers/casino/login_attempts_controller.rb
@@ -1,5 +1,5 @@
-class CASino::LoginAttemptsController < CASino::ApplicationController
-  include CASino::SessionsHelper
+class Casino::LoginAttemptsController < Casino::ApplicationController
+  include Casino::SessionsHelper
 
   before_action :ensure_signed_in, only: [:index]
 

--- a/app/controllers/casino/proxy_tickets_controller.rb
+++ b/app/controllers/casino/proxy_tickets_controller.rb
@@ -1,5 +1,5 @@
-class CASino::ProxyTicketsController < CASino::ApplicationController
-  include CASino::ControllerConcern::TicketValidator
+class Casino::ProxyTicketsController < Casino::ApplicationController
+  include Casino::ControllerConcern::TicketValidator
 
   before_action :load_ticket, only: [:proxy_validate]
   before_action :ensure_service_ticket_parameters_present, only: [:proxy_validate]
@@ -20,14 +20,14 @@ class CASino::ProxyTicketsController < CASino::ApplicationController
   def load_ticket
     @ticket = case params[:ticket]
               when /\APT-/
-                CASino::ProxyTicket.where(ticket: params[:ticket]).first
+                Casino::ProxyTicket.where(ticket: params[:ticket]).first
               when /\AST-/
-                CASino::ServiceTicket.where(ticket: params[:ticket]).first
+                Casino::ServiceTicket.where(ticket: params[:ticket]).first
               end
   end
 
   def build_proxy_response(success, options = {})
-    render xml: CASino::ProxyResponseBuilder.new(success, options).build
+    render xml: Casino::ProxyResponseBuilder.new(success, options).build
   end
 
   def ensure_proxy_parameters_present
@@ -39,7 +39,7 @@ class CASino::ProxyTicketsController < CASino::ApplicationController
   end
 
   def load_proxy_granting_ticket
-    @proxy_granting_ticket = CASino::ProxyGrantingTicket.where(ticket: params[:pgt]).first if params[:pgt].present?
+    @proxy_granting_ticket = Casino::ProxyGrantingTicket.where(ticket: params[:pgt]).first if params[:pgt].present?
     if @proxy_granting_ticket.nil?
       build_proxy_response(false,
                            error_code: 'BAD_PGT',

--- a/app/controllers/casino/service_tickets_controller.rb
+++ b/app/controllers/casino/service_tickets_controller.rb
@@ -1,5 +1,5 @@
-class CASino::ServiceTicketsController < CASino::ApplicationController
-  include CASino::ControllerConcern::TicketValidator
+class Casino::ServiceTicketsController < Casino::ApplicationController
+  include Casino::ControllerConcern::TicketValidator
 
   before_action :load_service_ticket
   before_action :ensure_service_ticket_parameters_present, only: [:service_validate]
@@ -17,6 +17,6 @@ class CASino::ServiceTicketsController < CASino::ApplicationController
 
   private
   def load_service_ticket
-    @service_ticket = CASino::ServiceTicket.where(ticket: params[:ticket]).first if params[:service].present?
+    @service_ticket = Casino::ServiceTicket.where(ticket: params[:ticket]).first if params[:service].present?
   end
 end

--- a/app/controllers/casino/sessions_controller.rb
+++ b/app/controllers/casino/sessions_controller.rb
@@ -1,7 +1,7 @@
-class CASino::SessionsController < CASino::ApplicationController
-  include CASino::SessionsHelper
-  include CASino::AuthenticationProcessor
-  include CASino::TwoFactorAuthenticatorProcessor
+class Casino::SessionsController < Casino::ApplicationController
+  include Casino::SessionsHelper
+  include Casino::AuthenticationProcessor
+  include Casino::TwoFactorAuthenticatorProcessor
 
   before_action :validate_login_ticket, only: [:create]
   before_action :ensure_service_allowed, only: [:new, :create]
@@ -68,7 +68,7 @@ class CASino::SessionsController < CASino::ApplicationController
   end
 
   def validate_login_ticket
-    unless CASino::LoginTicket.consume(params[:lt])
+    unless Casino::LoginTicket.consume(params[:lt])
       show_login_error I18n.t('login_credential_acceptor.invalid_login_ticket')
     end
   end

--- a/app/controllers/casino/two_factor_authenticators_controller.rb
+++ b/app/controllers/casino/two_factor_authenticators_controller.rb
@@ -1,9 +1,9 @@
 require 'rotp'
 
-class CASino::TwoFactorAuthenticatorsController < CASino::ApplicationController
-  include CASino::SessionsHelper
-  include CASino::TwoFactorAuthenticatorsHelper
-  include CASino::TwoFactorAuthenticatorProcessor
+class Casino::TwoFactorAuthenticatorsController < Casino::ApplicationController
+  include Casino::SessionsHelper
+  include Casino::TwoFactorAuthenticatorsHelper
+  include Casino::TwoFactorAuthenticatorProcessor
 
   before_action :ensure_signed_in
 

--- a/app/helpers/casino/sessions_helper.rb
+++ b/app/helpers/casino/sessions_helper.rb
@@ -1,8 +1,8 @@
 require 'addressable/uri'
 
-module CASino::SessionsHelper
-  include CASino::TicketGrantingTicketProcessor
-  include CASino::ServiceTicketProcessor
+module Casino::SessionsHelper
+  include Casino::TicketGrantingTicketProcessor
+  include Casino::ServiceTicketProcessor
 
   def current_ticket_granting_ticket?(ticket_granting_ticket)
     ticket_granting_ticket.ticket == cookies[:tgt]
@@ -24,7 +24,7 @@ module CASino::SessionsHelper
   end
 
   def current_authenticator_context
-    CASino.config.authenticator_context_builder.call(params, request)
+    Casino.config.authenticator_context_builder.call(params, request)
   end
 
   def ensure_signed_in
@@ -45,7 +45,7 @@ module CASino::SessionsHelper
   def set_tgt_cookie(tgt)
     cookies[:tgt] = { value: tgt.ticket }.tap do |cookie|
       if tgt.long_term?
-        cookie[:expires] = CASino.config.ticket_granting_ticket[:lifetime_long_term].seconds.from_now
+        cookie[:expires] = Casino.config.ticket_granting_ticket[:lifetime_long_term].seconds.from_now
       end
     end
   end
@@ -56,7 +56,7 @@ module CASino::SessionsHelper
   end
 
   def log_failed_login(username)
-    CASino::User.where(username: username).each do |user|
+    Casino::User.where(username: username).each do |user|
       create_login_attempt(user, false)
     end
   end

--- a/app/helpers/casino/two_factor_authenticators_helper.rb
+++ b/app/helpers/casino/two_factor_authenticators_helper.rb
@@ -1,9 +1,9 @@
 require 'rqrcode'
 require 'rqrcode_png'
 
-module CASino::TwoFactorAuthenticatorsHelper
+module Casino::TwoFactorAuthenticatorsHelper
   def otp_auth_url(two_factor_authenticator)
-    "otpauth://totp/#{u CASino.config.frontend[:sso_name] + ': ' + two_factor_authenticator.user.username}?secret=#{two_factor_authenticator.secret}&issuer=#{u CASino.config.frontend[:sso_name]}"
+    "otpauth://totp/#{u Casino.config.frontend[:sso_name] + ': ' + two_factor_authenticator.user.username}?secret=#{two_factor_authenticator.secret}&issuer=#{u Casino.config.frontend[:sso_name]}"
   end
 
   def otp_qr_code_data_url(two_factor_authenticator)

--- a/app/models/casino/application_record.rb
+++ b/app/models/casino/application_record.rb
@@ -1,3 +1,3 @@
-class CASino::ApplicationRecord < ActiveRecord::Base
+class Casino::ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/app/models/casino/auth_token_ticket.rb
+++ b/app/models/casino/auth_token_ticket.rb
@@ -1,14 +1,14 @@
-class CASino::AuthTokenTicket < CASino::ApplicationRecord
-  include CASino::ModelConcern::Ticket
-  include CASino::ModelConcern::ConsumableTicket
+class Casino::AuthTokenTicket < Casino::ApplicationRecord
+  include Casino::ModelConcern::Ticket
+  include Casino::ModelConcern::ConsumableTicket
 
   self.ticket_prefix = 'ATT'.freeze
 
   def self.cleanup
-    where(['created_at < ?', CASino.config.auth_token_ticket[:lifetime].seconds.ago]).delete_all
+    where(['created_at < ?', Casino.config.auth_token_ticket[:lifetime].seconds.ago]).delete_all
   end
 
   def expired?
-    (Time.now - (created_at || Time.now)) > CASino.config.auth_token_ticket[:lifetime].seconds
+    (Time.now - (created_at || Time.now)) > Casino.config.auth_token_ticket[:lifetime].seconds
   end
 end

--- a/app/models/casino/login_attempt.rb
+++ b/app/models/casino/login_attempt.rb
@@ -1,5 +1,5 @@
-class CASino::LoginAttempt < CASino::ApplicationRecord
-  include CASino::ModelConcern::BrowserInfo
+class Casino::LoginAttempt < Casino::ApplicationRecord
+  include Casino::ModelConcern::BrowserInfo
 
   belongs_to :user
 end

--- a/app/models/casino/login_ticket.rb
+++ b/app/models/casino/login_ticket.rb
@@ -1,14 +1,14 @@
-class CASino::LoginTicket < CASino::ApplicationRecord
-  include CASino::ModelConcern::Ticket
-  include CASino::ModelConcern::ConsumableTicket
+class Casino::LoginTicket < Casino::ApplicationRecord
+  include Casino::ModelConcern::Ticket
+  include Casino::ModelConcern::ConsumableTicket
 
   self.ticket_prefix = 'LT'.freeze
 
   def self.cleanup
-    where(['created_at < ?', CASino.config.login_ticket[:lifetime].seconds.ago]).delete_all
+    where(['created_at < ?', Casino.config.login_ticket[:lifetime].seconds.ago]).delete_all
   end
 
   def expired?
-    (Time.now - (created_at || Time.now)) > CASino.config.login_ticket[:lifetime].seconds
+    (Time.now - (created_at || Time.now)) > Casino.config.login_ticket[:lifetime].seconds
   end
 end

--- a/app/models/casino/model_concern.rb
+++ b/app/models/casino/model_concern.rb
@@ -1,0 +1,3 @@
+module Casino::ModelConcern
+  extend ActiveSupport::Concern
+end

--- a/app/models/casino/model_concern/browser_info.rb
+++ b/app/models/casino/model_concern/browser_info.rb
@@ -1,4 +1,4 @@
-module CASino::ModelConcern::BrowserInfo
+module Casino::ModelConcern::BrowserInfo
   extend ActiveSupport::Concern
 
   def browser_info

--- a/app/models/casino/model_concern/consumable_ticket.rb
+++ b/app/models/casino/model_concern/consumable_ticket.rb
@@ -1,4 +1,4 @@
-module CASino::ModelConcern::ConsumableTicket
+module Casino::ModelConcern::ConsumableTicket
   extend ActiveSupport::Concern
 
   module ClassMethods

--- a/app/models/casino/model_concern/ticket.rb
+++ b/app/models/casino/model_concern/ticket.rb
@@ -1,4 +1,4 @@
-module CASino::ModelConcern::Ticket
+module Casino::ModelConcern::Ticket
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/casino/proxy_granting_ticket.rb
+++ b/app/models/casino/proxy_granting_ticket.rb
@@ -1,6 +1,6 @@
 
-class CASino::ProxyGrantingTicket < CASino::ApplicationRecord
-  include CASino::ModelConcern::Ticket
+class Casino::ProxyGrantingTicket < Casino::ApplicationRecord
+  include Casino::ModelConcern::Ticket
 
   self.ticket_prefix = 'PGT'.freeze
 

--- a/app/models/casino/proxy_ticket.rb
+++ b/app/models/casino/proxy_ticket.rb
@@ -1,7 +1,7 @@
 require 'addressable/uri'
 
-class CASino::ProxyTicket < CASino::ApplicationRecord
-  include CASino::ModelConcern::Ticket
+class Casino::ProxyTicket < Casino::ApplicationRecord
+  include Casino::ModelConcern::Ticket
 
   self.ticket_prefix = 'PT'.freeze
 
@@ -10,18 +10,18 @@ class CASino::ProxyTicket < CASino::ApplicationRecord
   has_many :proxy_granting_tickets, as: :granter, dependent: :destroy
 
   def self.cleanup_unconsumed
-    where(['created_at < ? AND consumed = ?', CASino.config.proxy_ticket[:lifetime_unconsumed].seconds.ago, false]).destroy_all
+    self.where('created_at < ? AND consumed = ?', Casino.config.proxy_ticket[:lifetime_unconsumed].seconds.ago, false).delete_all
   end
 
   def self.cleanup_consumed
-    where(['created_at < ? AND consumed = ?', CASino.config.proxy_ticket[:lifetime_consumed].seconds.ago, true]).destroy_all
+    self.where('created_at < ? AND consumed = ?', Casino.config.proxy_ticket[:lifetime_consumed].seconds.ago, true).delete_all
   end
 
   def expired?
     lifetime = if consumed?
-      CASino.config.proxy_ticket[:lifetime_consumed]
+      Casino.config.proxy_ticket[:lifetime_consumed]
     else
-      CASino.config.proxy_ticket[:lifetime_unconsumed]
+      Casino.config.proxy_ticket[:lifetime_unconsumed]
     end
     (Time.now - (self.created_at || Time.now)) > lifetime
   end

--- a/app/models/casino/service_rule.rb
+++ b/app/models/casino/service_rule.rb
@@ -1,11 +1,11 @@
 
-class CASino::ServiceRule < CASino::ApplicationRecord
+class Casino::ServiceRule < Casino::ApplicationRecord
   validates :name, presence: true
   validates :url, uniqueness: true, presence: true
 
   def self.allowed?(service_url)
     rules = self.where(enabled: true)
-    if rules.empty? && !CASino.config.require_service_rules
+    if rules.empty? && !Casino.config.require_service_rules
       true
     else
       rules.any? { |rule| rule.allows?(service_url) }

--- a/app/models/casino/service_ticket/single_sign_out_notifier.rb
+++ b/app/models/casino/service_ticket/single_sign_out_notifier.rb
@@ -1,7 +1,7 @@
 require 'builder'
 require 'faraday'
 
-class CASino::ServiceTicket::SingleSignOutNotifier
+class Casino::ServiceTicket::SingleSignOutNotifier
   def initialize(service_ticket)
     @service_ticket = service_ticket
   end
@@ -28,7 +28,7 @@ class CASino::ServiceTicket::SingleSignOutNotifier
   def send_notification(url, xml)
     Rails.logger.info "Sending Single Sign Out notification for ticket '#{@service_ticket.ticket}'"
     result = Faraday.post(url, logoutRequest: xml) do |request|
-      request.options[:timeout] = CASino.config.service_ticket[:single_sign_out_notification][:timeout]
+      request.options[:timeout] = Casino.config.service_ticket[:single_sign_out_notification][:timeout]
     end
     if result.success?
       Rails.logger.info "Logout notification successfully posted to #{url}."

--- a/app/models/casino/ticket_granting_ticket.rb
+++ b/app/models/casino/ticket_granting_ticket.rb
@@ -1,8 +1,8 @@
 require 'user_agent'
 
-class CASino::TicketGrantingTicket < CASino::ApplicationRecord
-  include CASino::ModelConcern::Ticket
-  include CASino::ModelConcern::BrowserInfo
+class Casino::TicketGrantingTicket < Casino::ApplicationRecord
+  include Casino::ModelConcern::Ticket
+  include Casino::ModelConcern::BrowserInfo
 
   self.ticket_prefix = 'TGC'.freeze
 
@@ -19,13 +19,13 @@ class CASino::TicketGrantingTicket < CASino::ApplicationRecord
     end
     tgts = base.where([
       '(created_at < ? AND awaiting_two_factor_authentication = ?) OR (created_at < ? AND long_term = ?) OR created_at < ?',
-      CASino.config.two_factor_authenticator[:timeout].seconds.ago,
+      Casino.config.two_factor_authenticator[:timeout].seconds.ago,
       true,
-      CASino.config.ticket_granting_ticket[:lifetime].seconds.ago,
+      Casino.config.ticket_granting_ticket[:lifetime].seconds.ago,
       false,
-      CASino.config.ticket_granting_ticket[:lifetime_long_term].seconds.ago
+      Casino.config.ticket_granting_ticket[:lifetime_long_term].seconds.ago
     ])
-    CASino::ServiceTicket.where(ticket_granting_ticket_id: tgts).destroy_all
+    Casino::ServiceTicket.where(ticket_granting_ticket_id: tgts).destroy_all
     tgts.destroy_all
   end
 
@@ -39,11 +39,11 @@ class CASino::TicketGrantingTicket < CASino::ApplicationRecord
 
   def expired?
     if awaiting_two_factor_authentication?
-      lifetime = CASino.config.two_factor_authenticator[:timeout]
+      lifetime = Casino.config.two_factor_authenticator[:timeout]
     elsif long_term?
-      lifetime = CASino.config.ticket_granting_ticket[:lifetime_long_term]
+      lifetime = Casino.config.ticket_granting_ticket[:lifetime_long_term]
     else
-      lifetime = CASino.config.ticket_granting_ticket[:lifetime]
+      lifetime = Casino.config.ticket_granting_ticket[:lifetime]
     end
     (Time.now - (self.created_at || Time.now)) > lifetime
   end

--- a/app/models/casino/two_factor_authenticator.rb
+++ b/app/models/casino/two_factor_authenticator.rb
@@ -1,5 +1,5 @@
 
-class CASino::TwoFactorAuthenticator < CASino::ApplicationRecord
+class Casino::TwoFactorAuthenticator < Casino::ApplicationRecord
   belongs_to :user
 
   scope :active, -> { where(active: true) }
@@ -9,7 +9,7 @@ class CASino::TwoFactorAuthenticator < CASino::ApplicationRecord
   end
 
   def self.lifetime
-    CASino.config.two_factor_authenticator[:lifetime_inactive].seconds
+    Casino.config.two_factor_authenticator[:lifetime_inactive].seconds
   end
 
   def expired?

--- a/app/models/casino/user.rb
+++ b/app/models/casino/user.rb
@@ -1,6 +1,6 @@
 
-class CASino::User < CASino::ApplicationRecord
-  serialize :extra_attributes, Hash
+class Casino::User < Casino::ApplicationRecord
+  attr_accessor :fullname, :age, :roles
 
   has_many :ticket_granting_tickets
   has_many :two_factor_authenticators
@@ -8,5 +8,16 @@ class CASino::User < CASino::ApplicationRecord
 
   def active_two_factor_authenticator
     self.two_factor_authenticators.where(active: true).first
+  end
+
+  def extra_attributes
+    JSON.parse(read_attribute(:extra_attributes) || '{}')
+  rescue JSON::ParserError
+    {}
+  end
+
+  # Setter for extra_attributes
+  def extra_attributes=(value)
+    write_attribute(:extra_attributes, value.to_json)
   end
 end

--- a/app/models/casino/validation_result.rb
+++ b/app/models/casino/validation_result.rb
@@ -1,4 +1,4 @@
-class CASino::ValidationResult < Struct.new(:error_code, :error_message, :error_severity)
+class Casino::ValidationResult < Struct.new(:error_code, :error_message, :error_severity)
   def success?
     self.error_code.nil?
   end

--- a/app/processors/casino/authentication_processor.rb
+++ b/app/processors/casino/authentication_processor.rb
@@ -1,6 +1,6 @@
 require 'casino/authenticator'
 
-module CASino::AuthenticationProcessor
+module Casino::AuthenticationProcessor
   extend ActiveSupport::Concern
 
   def validate_login_credentials(username, password, context = nil)
@@ -14,7 +14,7 @@ module CASino::AuthenticationProcessor
         credentials.pop if authenticator.class.instance_method(:validate).arity == 2
 
         data = authenticator.validate(*credentials)
-      rescue CASino::Authenticator::AuthenticatorError => e
+      rescue Casino::Authenticator::AuthenticatorError => e
         Rails.logger.error "Authenticator '#{authenticator_name}' (#{authenticator.class}) raised an error: #{e}"
       end
       if data
@@ -35,7 +35,7 @@ module CASino::AuthenticationProcessor
 
   def authenticators
     @authenticators ||= {}.tap do |authenticators|
-      CASino.config[:authenticators].each do |name, auth|
+      Casino.config[:authenticators].each do |name, auth|
         next unless auth.is_a?(Hash)
 
         authenticator = if auth[:class]
@@ -54,8 +54,8 @@ module CASino::AuthenticationProcessor
     gemname, classname = parse_name(name)
 
     begin
-      require gemname unless CASino.const_defined?(classname)
-      CASino.const_get(classname)
+      require gemname unless Casino.const_defined?(classname)
+      Casino.const_get(classname)
     rescue LoadError => error
       raise LoadError, load_error_message(name, gemname, error)
     rescue NameError => error
@@ -75,7 +75,7 @@ module CASino::AuthenticationProcessor
 
   def name_error_message(name, error)
     "Failed to load authenticator '#{name}'. The authenticator class must " \
-      "be defined in the CASino namespace.\n" \
+      "be defined in the Casino namespace.\n" \
       "  Error: #{error.message}\n"
   end
 end

--- a/app/processors/casino/browser_processor.rb
+++ b/app/processors/casino/browser_processor.rb
@@ -1,4 +1,4 @@
-module CASino::BrowserProcessor
+module Casino::BrowserProcessor
   extend ActiveSupport::Concern
 
   def browser_info(user_agent)

--- a/app/processors/casino/proxy_granting_ticket_processor.rb
+++ b/app/processors/casino/proxy_granting_ticket_processor.rb
@@ -1,6 +1,6 @@
 require 'faraday'
 
-module CASino::ProxyGrantingTicketProcessor
+module Casino::ProxyGrantingTicketProcessor
   extend ActiveSupport::Concern
 
   def acquire_proxy_granting_ticket(pgt_url, service_ticket)

--- a/app/processors/casino/service_ticket_processor.rb
+++ b/app/processors/casino/service_ticket_processor.rb
@@ -1,15 +1,15 @@
 require 'addressable/uri'
 
-module CASino::ServiceTicketProcessor
+module Casino::ServiceTicketProcessor
   extend ActiveSupport::Concern
 
   class ServiceNotAllowedError < StandardError; end
-  class ValidationResult < CASino::ValidationResult; end
+  class ValidationResult < Casino::ValidationResult; end
 
   RESERVED_CAS_PARAMETER_KEYS = ['service', 'ticket', 'gateway', 'renew']
 
   def service_allowed?(service)
-    CASino::ServiceRule.allowed?(service)
+    Casino::ServiceRule.allowed?(service)
   end
 
   def acquire_service_ticket(ticket_granting_ticket, service, options = {})
@@ -67,7 +67,7 @@ module CASino::ServiceTicketProcessor
 
   private
   def validate_existing_ticket_for_service(ticket, service, options = {})
-    service = clean_service_url(service) if ticket.is_a?(CASino::ServiceTicket)
+    service = clean_service_url(service) if ticket.is_a?(Casino::ServiceTicket)
     if ticket.consumed?
       ValidationResult.new 'INVALID_TICKET', "Ticket '#{ticket.ticket}' already consumed", :warn
     elsif ticket.expired?

--- a/app/processors/casino/ticket_granting_ticket_processor.rb
+++ b/app/processors/casino/ticket_granting_ticket_processor.rb
@@ -1,10 +1,12 @@
-module CASino::TicketGrantingTicketProcessor
+require_dependency 'casino/browser_processor'
+
+module Casino::TicketGrantingTicketProcessor
   extend ActiveSupport::Concern
 
-  include CASino::BrowserProcessor
+  include Casino::BrowserProcessor
 
   def find_valid_ticket_granting_ticket(ticket, user_agent, options = {})
-    tgt = CASino::TicketGrantingTicket.where(ticket: ticket).first
+    tgt = Casino::TicketGrantingTicket.where(ticket: ticket).first
     unless tgt.nil?
       if tgt.expired?
         Rails.logger.info "Ticket-granting ticket expired (Created: #{tgt.created_at})"
@@ -38,7 +40,7 @@ module CASino::TicketGrantingTicketProcessor
   end
 
   def load_or_initialize_user(authenticator, username, extra_attributes)
-    user = CASino::User
+    user = Casino::User
       .where(authenticator: authenticator, username: username)
       .first_or_initialize
     user.extra_attributes = extra_attributes
@@ -52,6 +54,6 @@ module CASino::TicketGrantingTicketProcessor
   end
 
   def cleanup_expired_ticket_granting_tickets(user)
-    CASino::TicketGrantingTicket.cleanup(user)
+    Casino::TicketGrantingTicket.cleanup(user)
   end
 end

--- a/app/processors/casino/two_factor_authenticator_processor.rb
+++ b/app/processors/casino/two_factor_authenticator_processor.rb
@@ -1,17 +1,17 @@
 require 'rotp'
 
-module CASino::TwoFactorAuthenticatorProcessor
+module Casino::TwoFactorAuthenticatorProcessor
   extend ActiveSupport::Concern
 
   def validate_one_time_password(otp, authenticator)
     if authenticator.nil? || authenticator.expired?
-      CASino::ValidationResult.new 'INVALID_AUTHENTICATOR', 'Authenticator does not exist or expired', :warn
+      Casino::ValidationResult.new 'INVALID_AUTHENTICATOR', 'Authenticator does not exist or expired', :warn
     else
       totp = ROTP::TOTP.new(authenticator.secret)
-      if totp.verify_with_drift(otp, CASino.config.two_factor_authenticator[:drift])
-        CASino::ValidationResult.new
+      if totp.verify_with_drift(otp, Casino.config.two_factor_authenticator[:drift])
+        Casino::ValidationResult.new
       else
-        CASino::ValidationResult.new 'INVALID_OTP', 'One-time password not valid', :warn
+        Casino::ValidationResult.new 'INVALID_OTP', 'One-time password not valid', :warn
       end
     end
   end

--- a/app/services/casino/auth_token_validation_service.rb
+++ b/app/services/casino/auth_token_validation_service.rb
@@ -1,5 +1,5 @@
-class CASino::AuthTokenValidationService
-  include CASino::AuthenticationProcessor
+class Casino::AuthTokenValidationService
+  include Casino::AuthenticationProcessor
 
   AUTH_TOKEN_SIGNERS_GLOB = Rails.root.join('config/auth_token_signers/*.pem').freeze
 
@@ -55,12 +55,12 @@ class CASino::AuthTokenValidationService
   end
 
   def ticket_valid?
-    CASino::AuthTokenTicket.consume(token_data[:ticket]).tap do |is_valid|
+    Casino::AuthTokenTicket.consume(token_data[:ticket]).tap do |is_valid|
       Rails.logger.warn('Could not find a valid auth token ticket.') unless is_valid
     end
   end
 
   def authentication_service
-    @authentication_service ||= CASino::AuthenticationService.new
+    @authentication_service ||= Casino::AuthenticationService.new
   end
 end

--- a/app/views/casino/application/_footer.html.erb
+++ b/app/views/casino/application/_footer.html.erb
@@ -1,3 +1,3 @@
   <div id="footer">
-    <%= CASino.config.frontend[:footer_text].html_safe %>
+    <%= Casino.config.frontend[:footer_text].html_safe %>
   </div>

--- a/app/views/casino/login_attempts/_table.html.erb
+++ b/app/views/casino/login_attempts/_table.html.erb
@@ -1,25 +1,25 @@
 <table width="100%" class="login_attempts">
   <thead>
     <tr>
-      <th class="browser_info"><%= CASino::LoginAttempt.human_attribute_name(:browser_info) %></th>
-      <th class="user_ip"><%= CASino::LoginAttempt.human_attribute_name(:user_ip) %></th>
-      <th class="created_at"><%= CASino::LoginAttempt.human_attribute_name(:created_at) %></th>
-      <th class="successful"><%= CASino::LoginAttempt.human_attribute_name(:successful) %></th>
+      <th class="browser_info"><%= Casino::LoginAttempt.human_attribute_name(:browser_info) %></th>
+      <th class="user_ip"><%= Casino::LoginAttempt.human_attribute_name(:user_ip) %></th>
+      <th class="created_at"><%= Casino::LoginAttempt.human_attribute_name(:created_at) %></th>
+      <th class="successful"><%= Casino::LoginAttempt.human_attribute_name(:successful) %></th>
     </tr>
   </thead>
   <tbody>
     <% @login_attempts.each do |login_attempt| %>
       <tr>
-        <td data-label="<%= CASino::LoginAttempt.human_attribute_name(:browser_info) %>">
+        <td data-label="<%= Casino::LoginAttempt.human_attribute_name(:browser_info) %>">
           <%= login_attempt.browser_info %>
         </td>
-        <td data-label="<%= CASino::LoginAttempt.human_attribute_name(:user_ip) %>">
+        <td data-label="<%= Casino::LoginAttempt.human_attribute_name(:user_ip) %>">
           <%= login_attempt.user_ip %>
         </td>
-        <td data-label="<%= CASino::LoginAttempt.human_attribute_name(:created_at) %>">
+        <td data-label="<%= Casino::LoginAttempt.human_attribute_name(:created_at) %>">
           <%= l login_attempt.created_at %>
         </td>
-        <td class="successful" data-label="<%= CASino::LoginAttempt.human_attribute_name(:successful) %>">
+        <td class="successful" data-label="<%= Casino::LoginAttempt.human_attribute_name(:successful) %>">
           <%= (login_attempt.successful ? '&#9989;' : '&#10060;').html_safe %>
         </td>
       </tr>

--- a/app/views/casino/login_attempts/index.html.erb
+++ b/app/views/casino/login_attempts/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="login_attempts_index box">
     <div class="info">
-      <h1><%= CASino::LoginAttempt.model_name.human(count: 2) %></h1>
+      <h1><%= Casino::LoginAttempt.model_name.human(count: 2) %></h1>
       <%= link_to t('shared.back'), sessions_path, :class => 'button' %>
     </div>
 

--- a/app/views/casino/sessions/new.html.erb
+++ b/app/views/casino/sessions/new.html.erb
@@ -13,7 +13,7 @@
 
     <div class="form">
       <%= form_tag(login_path, method: :post, id: 'login-form') do %>
-        <%= hidden_field_tag :lt, CASino::LoginTicket.create.ticket %>
+        <%= hidden_field_tag :lt, Casino::LoginTicket.create.ticket %>
         <%= hidden_field_tag :service, params[:service] unless params[:service].blank? %>
         <%= label_tag :username, t('login.label_username') %>
         <%= text_field_tag :username, params[:username], autofocus:true %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title><%= CASino.config.frontend[:sso_name] %></title>
+  <title><%= Casino.config.frontend[:sso_name] %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <%= stylesheet_link_tag    "application", :media => "all" %>
   <%= javascript_include_tag "application" %>

--- a/casino.gemspec
+++ b/casino.gemspec
@@ -4,15 +4,16 @@ require 'casino/version'
 
 Gem::Specification.new do |s|
   s.name        = 'casino'
-  s.version     = CASino::VERSION
+  s.version     = Casino::VERSION
   s.authors     = ['Nils Caspar', 'Raffael Schmid', 'Samuel Sieg']
   s.email       = ['ncaspar@me.com', 'raffael@yux.ch', 'samuel.sieg@me.com']
   s.homepage    = 'http://rbcas.org/'
   s.license     = 'MIT'
   s.summary     = 'A simple CAS server written in Ruby using the Rails framework.'
-  s.description = 'CASino is a simple CAS (Central Authentication Service) server.'
-
-  s.files         = `git ls-files`.split("\n")
+  s.description = 'Casino is a simple CAS (Central Authentication Service) server.'
+  s.files = Dir.chdir(File.expand_path(__dir__)) do
+    Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
+  end
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
@@ -23,15 +24,15 @@ Gem::Specification.new do |s|
     s.cert_chain  = ['casino-public_cert.pem']
   end
 
-  s.add_runtime_dependency 'addressable', '>= 2.3'
-  s.add_runtime_dependency 'faraday', '>= 0.8'
-  s.add_runtime_dependency 'grape', '>= 0.8'
-  s.add_runtime_dependency 'grape-entity', '>= 0.4'
-  s.add_runtime_dependency 'kaminari', '~> 1.0'
-  s.add_runtime_dependency 'rails', '>= 4.2'
-  s.add_runtime_dependency 'rotp', '>= 2.0'
-  s.add_runtime_dependency 'rqrcode_png', '>= 0.1'
+  s.add_runtime_dependency 'rails', '> 7.0.0'
   s.add_runtime_dependency 'sass-rails', '>= 4.0.0'
-  s.add_runtime_dependency 'terminal-table', '>= 1.4'
-  s.add_runtime_dependency 'useragent', '>= 0.4'
+  s.add_runtime_dependency 'addressable', '~> 2.8.7'
+  s.add_runtime_dependency 'terminal-table', '~> 1.8'
+  s.add_runtime_dependency 'useragent', '~> 0.16.10'
+  s.add_runtime_dependency 'faraday', '~> 0.17.6'
+  s.add_runtime_dependency 'rotp', '~> 6.3.0'
+  s.add_runtime_dependency 'grape', '~> 2.2.0'
+  s.add_runtime_dependency 'grape-entity', '~> 1.0.1'
+  s.add_runtime_dependency 'rqrcode_png_with_fixes', '~> 0.1.6'
+  s.add_runtime_dependency 'kaminari', '~> 1.2.2'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Casino::Engine.routes.draw do
-  mount Casino::API => '/api'
+  mount Casino::Api => '/api'
 
   resources :sessions, only: [:index, :destroy]
   resources :two_factor_authenticators, only: [:new, :create, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
-CASino::Engine.routes.draw do
-  mount CASino::API => '/api'
+Casino::Engine.routes.draw do
+  mount Casino::API => '/api'
 
   resources :sessions, only: [:index, :destroy]
   resources :two_factor_authenticators, only: [:new, :create, :destroy]

--- a/db/migrate/20130809135400_create_core_schema.rb
+++ b/db/migrate/20130809135400_create_core_schema.rb
@@ -1,5 +1,5 @@
-# In order to support pre-2.0 installations of CASino that included CASinoCore,
-# we must rebuild the un-namespaced CASinoCore schema so that we can upgrade
+# In order to support pre-2.0 installations of Casino that included CasinoCore,
+# we must rebuild the un-namespaced CasinoCore schema so that we can upgrade
 class CreateCoreSchema < ActiveRecord::Migration[4.1]
   CoreTables = %w{login_tickets proxy_granting_tickets proxy_tickets service_rules service_tickets ticket_granting_tickets two_factor_authenticators users}
 

--- a/db/migrate/20131022110146_cleanup_indexes.rb
+++ b/db/migrate/20131022110146_cleanup_indexes.rb
@@ -1,6 +1,6 @@
 class CleanupIndexes < ActiveRecord::Migration[4.1]
   def change
-    # delete some leftovers in migrated CASino 1.x installations
+    # delete some leftovers in migrated Casino 1.x installations
     remove_deprecated_index_if_exists :login_tickets, [:ticket]
     remove_deprecated_index_if_exists :proxy_granting_tickets, [:granter_type, :granter_id]
     remove_deprecated_index_if_exists :proxy_granting_tickets, [:iou]

--- a/lib/casino.rb
+++ b/lib/casino.rb
@@ -1,7 +1,7 @@
 require 'active_support/configurable'
 require 'casino/engine'
 
-module CASino
+module Casino
   include ActiveSupport::Configurable
 
   defaults = {
@@ -10,8 +10,8 @@ module CASino
     require_service_rules: false,
     logger: Rails.logger,
     frontend: HashWithIndifferentAccess.new(
-      sso_name: 'CASino',
-      footer_text: 'Powered by <a href="http://rbcas.com/">CASino</a>'
+      sso_name: 'Casino',
+      footer_text: 'Powered by <a href="http://rbcas.com/">Casino</a>'
     ),
     implementors: HashWithIndifferentAccess.new(
       login_ticket: nil,

--- a/lib/casino/authenticator.rb
+++ b/lib/casino/authenticator.rb
@@ -1,4 +1,4 @@
-module CASino
+module Casino
   class Authenticator
     class AuthenticatorError < StandardError; end
 

--- a/lib/casino/engine.rb
+++ b/lib/casino/engine.rb
@@ -2,9 +2,9 @@ require 'casino'
 require 'casino/inflections'
 require 'yaml'
 
-module CASino
+module Casino
   class Engine < Rails::Engine
-    isolate_namespace CASino
+    isolate_namespace Casino
 
     rake_tasks { require 'casino/tasks' }
 
@@ -17,11 +17,11 @@ module CASino
       cfg = (YAML.load(ERB.new(yaml).result)||{}).fetch(Rails.env, {})
       cfg.each do |k,v|
         value = if v.is_a? Hash
-          CASino.config.fetch(k.to_sym,{}).merge(v.symbolize_keys)
+          Casino.config.fetch(k.to_sym,{}).merge(v.symbolize_keys)
         else
           v
         end
-        CASino.config.send("#{k}=", value)
+        Casino.config.send("#{k}=", value)
       end
     end
 

--- a/lib/casino/inflections.rb
+++ b/lib/casino/inflections.rb
@@ -2,5 +2,5 @@
 # the Railtie is going to declare a table_name_suffix based upon the name of the
 # Railtie. Without this definition, the Railtie would use 'ca_s_ino'
 ActiveSupport::Inflector.inflections do |inflect|
-  inflect.acronym 'CASino'
+  inflect.acronym 'Casino'
 end

--- a/lib/casino/tasks/authentication.rake
+++ b/lib/casino/tasks/authentication.rake
@@ -4,7 +4,7 @@ namespace :casino do
   namespace :authentication do
     desc 'Test authentication.'
     task test: :environment do |task, args|
-      include CASino::AuthenticationProcessor
+      include Casino::AuthenticationProcessor
       print "Username: "
       username = STDIN.gets.chomp
       print "Password (won't be shown): "
@@ -20,7 +20,7 @@ namespace :casino do
           else
             puts "Invalid credentials"
           end
-        rescue CASino::Authenticator::AuthenticatorError => e
+        rescue Casino::Authenticator::AuthenticatorError => e
           puts "#{e}"
         end
       end

--- a/lib/casino/tasks/cleanup.rake
+++ b/lib/casino/tasks/cleanup.rake
@@ -7,45 +7,45 @@ namespace :casino do
     desc 'Remove expired service tickets.'
     task service_tickets: :environment do
       [:consumed, :unconsumed].each do |type|
-        rows_affected = CASino::ServiceTicket.send("cleanup_#{type}")
+        rows_affected = Casino::ServiceTicket.send("cleanup_#{type}")
         if rows_affected.respond_to? :length
           rows_affected = rows_affected.length
         end
         puts "Deleted #{rows_affected} #{type} service tickets."
       end
-      rows_affected = CASino::ServiceTicket.cleanup_consumed_hard
+      rows_affected = Casino::ServiceTicket.cleanup_consumed_hard
       puts "Force deleted #{rows_affected} consumed service tickets."
     end
 
     desc 'Remove expired proxy tickets.'
     task proxy_tickets: :environment do
       [:consumed, :unconsumed].each do |type|
-        rows_affected = CASino::ProxyTicket.send("cleanup_#{type}").length
+        rows_affected = Casino::ProxyTicket.send("cleanup_#{type}").length
         puts "Deleted #{rows_affected} #{type} proxy tickets."
       end
     end
 
     desc 'Remove expired login tickets.'
     task login_tickets: :environment do
-      rows_affected = CASino::LoginTicket.cleanup
+      rows_affected = Casino::LoginTicket.cleanup
       puts "Deleted #{rows_affected} login tickets."
     end
 
     desc 'Remove expired auth token tickets.'
     task auth_token_tickets: :environment do
-      rows_affected = CASino::AuthTokenTicket.cleanup
+      rows_affected = Casino::AuthTokenTicket.cleanup
       puts "Deleted #{rows_affected} auth token tickets."
     end
 
     desc 'Remove expired inactive two-factor authenticators.'
     task two_factor_authenticators: :environment do
-      rows_affected = CASino::TwoFactorAuthenticator.cleanup
+      rows_affected = Casino::TwoFactorAuthenticator.cleanup
       puts "Deleted #{rows_affected} inactive two-factor authenticators."
     end
 
     desc 'Remove expired ticket-granting tickets.'
     task ticket_granting_tickets: :environment do
-      rows_affected = CASino::TicketGrantingTicket.cleanup.length
+      rows_affected = Casino::TicketGrantingTicket.cleanup.length
       puts "Deleted #{rows_affected} ticket-granting tickets."
     end
 

--- a/lib/casino/tasks/service_rule.rake
+++ b/lib/casino/tasks/service_rule.rake
@@ -5,8 +5,8 @@ namespace :casino do
 
     desc 'Add a service rule (prefix the url parameter with "regex:" to add a regular expression)'
     task :add, [:name, :url] => :environment do |task, args|
-      include CASino::ServiceTicketProcessor
-      service_rule = CASino::ServiceRule.new name: args[:name]
+      include Casino::ServiceTicketProcessor
+      service_rule = Casino::ServiceRule.new name: args[:name]
       match = /^regex:(.*)/.match(args[:url])
       if match.nil?
         service_rule.url = clean_service_url(args[:url])
@@ -23,20 +23,20 @@ namespace :casino do
 
     desc 'Remove a servcice rule.'
     task :delete, [:id] => :environment do |task, args|
-      CASino::ServiceRule.find(args[:id]).delete
+      Casino::ServiceRule.find(args[:id]).delete
       puts "Successfully deleted service rule ##{args[:id]}."
     end
 
     desc 'Delete all servcice rules.'
     task :flush => :environment do |task, args|
-      CASino::ServiceRule.delete_all
+      Casino::ServiceRule.delete_all
       puts 'Successfully deleted all service rules.'
     end
 
     desc 'List all service rules.'
     task list: :environment do
       table = Terminal::Table.new :headings => ['Enabled', 'ID', 'Name', 'URL'] do |t|
-        CASino::ServiceRule.all.each do |service_rule|
+        Casino::ServiceRule.all.each do |service_rule|
           url = service_rule.url
           if service_rule.regex?
             url += " (Regex)"

--- a/lib/casino/tasks/user.rake
+++ b/lib/casino/tasks/user.rake
@@ -4,7 +4,7 @@ namespace :casino do
   namespace :user do
     desc 'Search users by name.'
     task :search, [:query] => :environment do |task, args|
-      users = CASino::User.where('username LIKE ?', "%#{args[:query]}%")
+      users = Casino::User.where('username LIKE ?', "%#{args[:query]}%")
       if users.any?
         headers = ['User ID', 'Username', 'Authenticator', 'Two-factor authentication enabled?']
         table = Terminal::Table.new :headings => headers do |t|
@@ -21,8 +21,8 @@ namespace :casino do
 
     desc 'Deactivate two-factor authentication for a user.'
     task :deactivate_two_factor_authentication, [:user_id] => :environment do |task, args|
-      if CASino::User.find(args[:user_id]).active_two_factor_authenticator
-        CASino::User.find(args[:user_id]).active_two_factor_authenticator.destroy
+      if Casino::User.find(args[:user_id]).active_two_factor_authenticator
+        Casino::User.find(args[:user_id]).active_two_factor_authenticator.destroy
         puts "Successfully deactivated two-factor authentication for user ##{args[:user_id]}."
       else
         puts "No two-factor authenticator found for user ##{args[:user_id]}."

--- a/lib/casino/version.rb
+++ b/lib/casino/version.rb
@@ -1,3 +1,3 @@
-module CASino
+module Casino
   VERSION = '5.0.0'.freeze
 end

--- a/lib/generators/casino/install/USAGE
+++ b/lib/generators/casino/install/USAGE
@@ -1,13 +1,13 @@
-CASino installation generator
+Casino installation generator
 
 Description:
-    The 'casino:install' command installs the CASino Rails Engine into your
+    The 'casino:install' command installs the Casino Rails Engine into your
     Rails application.
 
 Example:
     rails g casino:install
 
     This generates a few files inside your application that are required for
-    CASino to work properly.
+    Casino to work properly.
 
     See http://casino.rbcas.com for more information.

--- a/lib/generators/casino/install/install_generator.rb
+++ b/lib/generators/casino/install/install_generator.rb
@@ -1,4 +1,4 @@
-module CASino
+module Casino
   class InstallGenerator < Rails::Generators::Base
     source_root File.expand_path('../templates', __FILE__)
 
@@ -37,7 +37,7 @@ module CASino
     end
 
     def insert_engine_routes
-      route "mount CASino::Engine => '/', :as => 'casino'"
+      route "mount Casino::Engine => '/', :as => 'casino'"
     end
 
     def show_readme

--- a/lib/generators/casino/install/templates/README
+++ b/lib/generators/casino/install/templates/README
@@ -1,6 +1,6 @@
 ===============================================================================
 
-The CASino Engine has been correctly installed in your Rails application.
+The Casino Engine has been correctly installed in your Rails application.
 
   1. Edit the configuration file:
 
@@ -10,7 +10,7 @@ The CASino Engine has been correctly installed in your Rails application.
 
     - app/views/layouts/application.html.erb
 
-  3. Run the generated CASino migrations
+  3. Run the generated Casino migrations
 
     > bundle exec rake db:migrate SCOPE=casino
 

--- a/lib/generators/casino/install/templates/cas.yml
+++ b/lib/generators/casino/install/templates/cas.yml
@@ -8,14 +8,14 @@ defaults: &defaults
     lifetime_unconsumed: 300
     lifetime_consumed: 86400
   frontend:
-    sso_name: "CASino"
-    footer_text: "Powered by <a href=\"http://rbcas.com/\">CASino</a>"
+    sso_name: "Casino"
+    footer_text: "Powered by <a href=\"http://rbcas.com/\">Casino</a>"
 
 development:
   <<: *defaults
   authenticators:
     static:
-      class: "CASino::StaticAuthenticator"
+      class: "Casino::StaticAuthenticator"
       options:
         users:
           testuser:
@@ -25,7 +25,7 @@ test:
   <<: *defaults
   authenticators:
     static:
-      class: "CASino::StaticAuthenticator"
+      class: "Casino::StaticAuthenticator"
       options:
         users:
           testuser:

--- a/lib/generators/casino/install/templates/casino_and_overrides.scss
+++ b/lib/generators/casino/install/templates/casino_and_overrides.scss
@@ -1,5 +1,5 @@
 
-// Default CASino settings
+// Default Casino settings
 
 // $buttonColor: #0074ad;
 // $buttonSecondaryColor: #c2c2c2;

--- a/lib/generators/casino/migration_generator.rb
+++ b/lib/generators/casino/migration_generator.rb
@@ -1,13 +1,13 @@
 require 'rails/generators/active_record'
 
-module CASino
+module Casino
   class MigrationGenerator < ::Rails::Generators::Base
     include Rails::Generators::Migration
     source_root File.expand_path('../../../../db/migrate', __FILE__)
 
     namespace 'casino:migration'
 
-    desc 'Installs CASino migration files.'
+    desc 'Installs Casino migration files.'
     
     def install
       source_paths.each do |source_path|

--- a/lib/generators/casino/templates/casino_core.rb
+++ b/lib/generators/casino/templates/casino_core.rb
@@ -1,1 +1,1 @@
-CASino.setup Rails.env, application_root: Rails.root
+Casino.setup Rails.env, application_root: Rails.root

--- a/spec/authenticator/base_spec.rb
+++ b/spec/authenticator/base_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 require 'casino/authenticator'
 
-describe CASino::Authenticator do
+describe Casino::Authenticator do
   subject {
-    CASino::Authenticator.new
+    Casino::Authenticator.new
   }
 
   context '#validate' do

--- a/spec/authenticator/static_spec.rb
+++ b/spec/authenticator/static_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CASino::StaticAuthenticator do
+describe Casino::StaticAuthenticator do
   subject {
     described_class.new({
       users: {

--- a/spec/controllers/auth_tokens_controller_spec.rb
+++ b/spec/controllers/auth_tokens_controller_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-describe CASino::AuthTokensController do
-  routes { CASino::Engine.routes }
+describe Casino::AuthTokensController do
+  routes { Casino::Engine.routes }
 
   let(:params) { {} }
   let(:request_options) { {params: params} }
 
   before(:each) do
-    CASino::AuthTokenValidationService.any_instance.stub(:validation_result).and_return(validation_result)
+    Casino::AuthTokenValidationService.any_instance.stub(:validation_result).and_return(validation_result)
   end
 
   describe 'GET "authTokenLogin"' do
@@ -51,7 +51,7 @@ describe CASino::AuthTokensController do
         it 'generates a service ticket' do
           lambda do
             get :login, **request_options
-          end.should change(CASino::ServiceTicket, :count).by(1)
+          end.should change(Casino::ServiceTicket, :count).by(1)
         end
       end
 
@@ -63,7 +63,7 @@ describe CASino::AuthTokensController do
       it 'generates a ticket-granting ticket' do
         lambda do
           get :login, **request_options
-        end.should change(CASino::TicketGrantingTicket, :count).by(1)
+        end.should change(Casino::TicketGrantingTicket, :count).by(1)
       end
 
       it 'redirects to the session overview' do

--- a/spec/controllers/login_attempts_controller_spec.rb
+++ b/spec/controllers/login_attempts_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe CASino::LoginAttemptsController do
-  routes { CASino::Engine.routes }
+describe Casino::LoginAttemptsController do
+  routes { Casino::Engine.routes }
 
   describe 'GET #index' do
     context 'with ticket granting ticket' do

--- a/spec/controllers/proxy_tickets_controller_spec.rb
+++ b/spec/controllers/proxy_tickets_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe CASino::ProxyTicketsController do
-  routes { CASino::Engine.routes }
+describe Casino::ProxyTicketsController do
+  routes { Casino::Engine.routes }
 
   let(:request_options) { {params: params} }
 
@@ -30,7 +30,7 @@ describe CASino::ProxyTicketsController do
 
       context 'with an expired proxy ticket' do
         before(:each) do
-          CASino::ProxyTicket.any_instance.stub(:expired?).and_return(true)
+          Casino::ProxyTicket.any_instance.stub(:expired?).and_return(true)
         end
 
         it 'answers with the failure text' do
@@ -74,7 +74,7 @@ describe CASino::ProxyTicketsController do
       it 'does not create a proxy ticket' do
         lambda do
           get :create, **request_options
-        end.should_not change(CASino::ProxyTicket, :count)
+        end.should_not change(Casino::ProxyTicket, :count)
       end
     end
 
@@ -89,7 +89,7 @@ describe CASino::ProxyTicketsController do
       it 'does not create a proxy ticket' do
         lambda do
           get :create, **request_options
-        end.should_not change(CASino::ProxyTicket, :count)
+        end.should_not change(Casino::ProxyTicket, :count)
       end
     end
 
@@ -110,7 +110,7 @@ describe CASino::ProxyTicketsController do
 
       it 'includes the proxy ticket in the response' do
         get :create, **request_options
-        proxy_ticket = CASino::ProxyTicket.last
+        proxy_ticket = Casino::ProxyTicket.last
         response.body.should =~ /<cas:proxyTicket>#{proxy_ticket.ticket}<\/cas:proxyTicket>/
       end
 
@@ -125,7 +125,7 @@ describe CASino::ProxyTicketsController do
         it 'does not create a proxy ticket' do
           lambda do
             get :create, **request_options
-          end.should_not change(CASino::ProxyTicket, :count)
+          end.should_not change(Casino::ProxyTicket, :count)
         end
       end
     end

--- a/spec/controllers/service_and_proxy_tickets_controller_spec.rb
+++ b/spec/controllers/service_and_proxy_tickets_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 shared_examples_for 'a service ticket validator' do
-  routes { CASino::Engine.routes }
+  routes { Casino::Engine.routes }
 
   let(:request_options) { {params: params} }
   let(:service_ticket) { FactoryBot.create :service_ticket }
@@ -31,7 +31,7 @@ shared_examples_for 'a service ticket validator' do
     context 'with an unconsumed service ticket' do
       context 'with extra attributes using strings as keys' do
         before(:each) do
-          CASino::User.any_instance.stub(:extra_attributes).and_return({ "id" => 1234 })
+          Casino::User.any_instance.stub(:extra_attributes).and_return({ "id" => 1234 })
         end
 
         it 'includes the extra attributes' do
@@ -42,7 +42,7 @@ shared_examples_for 'a service ticket validator' do
 
       context 'with extra attributes using array as value' do
         before(:each) do
-          CASino::User.any_instance.stub(:extra_attributes).and_return({ "memberOf" => [ "test", "yolo" ] })
+          Casino::User.any_instance.stub(:extra_attributes).and_return({ "memberOf" => [ "test", "yolo" ] })
         end
 
         it 'includes all values' do
@@ -158,7 +158,7 @@ shared_examples_for 'a service ticket validator' do
 
         it 'contacts the callback server' do
           get validation_action, **request_options
-          proxy_granting_ticket = CASino::ProxyGrantingTicket.last
+          proxy_granting_ticket = Casino::ProxyGrantingTicket.last
           WebMock.should have_requested(:get, 'https://www.example.org').with(query: {
             pgtId: proxy_granting_ticket.ticket,
             pgtIou: proxy_granting_ticket.iou
@@ -214,12 +214,12 @@ shared_examples_for 'a service ticket validator' do
   end
 end
 
-describe CASino::ServiceTicketsController do
+describe Casino::ServiceTicketsController do
   let(:validation_action) { :service_validate }
   it_behaves_like 'a service ticket validator'
 end
 
-describe CASino::ProxyTicketsController do
+describe Casino::ProxyTicketsController do
   let(:validation_action) { :proxy_validate }
   it_behaves_like 'a service ticket validator'
 end

--- a/spec/controllers/service_tickets_controller_spec.rb
+++ b/spec/controllers/service_tickets_controller_spec.rb
@@ -1,5 +1,5 @@
-describe CASino::ServiceTicketsController do
-  routes { CASino::Engine.routes }
+describe Casino::ServiceTicketsController do
+  routes { Casino::Engine.routes }
 
   describe 'GET "validate"' do
     let(:request_options) { {params: params} }

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe CASino::SessionsController do
-  include CASino::Engine.routes.url_helpers
+describe Casino::SessionsController do
+  include Casino::Engine.routes.url_helpers
 
-  routes { CASino::Engine.routes }
+  routes { Casino::Engine.routes }
 
   let(:params) { {} }
   let(:request_options) { {params: params} }
@@ -94,12 +94,12 @@ describe CASino::SessionsController do
         end
 
         it 'generates a service ticket' do
-          -> { get :new, **request_options }.should change(CASino::ServiceTicket, :count).by(1)
+          -> { get :new, **request_options }.should change(Casino::ServiceTicket, :count).by(1)
         end
 
         it 'does not set the issued_from_credentials flag on the service ticket' do
           get :new, **request_options
-          CASino::ServiceTicket.last.should_not be_issued_from_credentials
+          Casino::ServiceTicket.last.should_not be_issued_from_credentials
         end
 
         context 'with renew parameter' do
@@ -139,7 +139,7 @@ describe CASino::SessionsController do
         end
 
         it 'does not generate a service ticket' do
-          -> { get :new, **request_options }.should change(CASino::ServiceTicket, :count).by(0)
+          -> { get :new, **request_options }.should change(Casino::ServiceTicket, :count).by(0)
         end
 
         context 'with a changed browser' do
@@ -198,14 +198,14 @@ describe CASino::SessionsController do
         it 'creates session log' do
           expect do
             post :create, **request_options
-          end.to change { CASino::LoginAttempt.count }.by 1
+          end.to change { Casino::LoginAttempt.count }.by 1
         end
 
         it 'assigns session log the correct attributes' do
           post :create, **request_options
 
-          expect(CASino::LoginAttempt.last.user).to eq user
-          expect(CASino::LoginAttempt.last.successful).to eq false
+          expect(Casino::LoginAttempt.last.user).to eq user
+          expect(Casino::LoginAttempt.last.successful).to eq false
         end
       end
 
@@ -222,21 +222,21 @@ describe CASino::SessionsController do
 
         it 'saves user_ip' do
           post :create, **request_options
-          tgt = CASino::TicketGrantingTicket.last
+          tgt = Casino::TicketGrantingTicket.last
           tgt.user_ip.should == '0.0.0.0'
         end
 
         it 'creates session log' do
           expect do
             post :create, **request_options
-          end.to change { CASino::LoginAttempt.count }.by 1
+          end.to change { Casino::LoginAttempt.count }.by 1
         end
 
         it 'assigns session log the correct attributes' do
           post :create, **request_options
 
-          expect(CASino::LoginAttempt.last.user.username).to eq username
-          expect(CASino::LoginAttempt.last.successful).to eq true
+          expect(Casino::LoginAttempt.last.user.username).to eq username
+          expect(Casino::LoginAttempt.last.successful).to eq true
         end
 
         context 'with rememberMe set' do
@@ -254,13 +254,13 @@ describe CASino::SessionsController do
 
           it 'creates a long-term ticket-granting ticket' do
             post :create, **request_options
-            tgt = CASino::TicketGrantingTicket.last
+            tgt = Casino::TicketGrantingTicket.last
             tgt.long_term.should == true
           end
         end
 
         context 'with two-factor authentication enabled' do
-          let!(:user) { CASino::User.create! username: username, authenticator: authenticator }
+          let!(:user) { Casino::User.create! username: username, authenticator: authenticator }
           let!(:two_factor_authenticator) { FactoryBot.create :two_factor_authenticator, user: user }
 
           it 'renders the validate_otp template' do
@@ -283,8 +283,8 @@ describe CASino::SessionsController do
 
         context 'when all authenticators raise an error' do
           before(:each) do
-            CASino::StaticAuthenticator.any_instance.stub(:validate) do
-              raise CASino::Authenticator::AuthenticatorError, 'error123'
+            Casino::StaticAuthenticator.any_instance.stub(:validate) do
+              raise Casino::Authenticator::AuthenticatorError, 'error123'
             end
           end
 
@@ -303,27 +303,27 @@ describe CASino::SessionsController do
           end
 
           it 'generates a ticket-granting ticket' do
-            -> { post :create, **request_options }.should change(CASino::TicketGrantingTicket, :count).by(1)
+            -> { post :create, **request_options }.should change(Casino::TicketGrantingTicket, :count).by(1)
           end
 
           context 'when the user does not exist yet' do
             it 'generates exactly one user' do
-              -> { post :create, **request_options }.should change(CASino::User, :count).by(1)
+              -> { post :create, **request_options }.should change(Casino::User, :count).by(1)
             end
 
             it 'sets the users attributes' do
               post :create, **request_options
-              user = CASino::User.last
+              user = Casino::User.last
               user.username.should == username
               user.authenticator.should == authenticator
             end
           end
 
           context 'when the user already exists' do
-            let!(:user) { CASino::User.create! username: username, authenticator: authenticator }
+            let!(:user) { Casino::User.create! username: username, authenticator: authenticator }
 
             it 'does not regenerate the user' do
-              -> { post :create, **request_options }.should_not change(CASino::User, :count)
+              -> { post :create, **request_options }.should_not change(Casino::User, :count)
             end
 
             it 'updates the extra attributes' do
@@ -344,16 +344,16 @@ describe CASino::SessionsController do
           end
 
           it 'generates a service ticket' do
-            -> { post :create, **request_options }.should change(CASino::ServiceTicket, :count).by(1)
+            -> { post :create, **request_options }.should change(Casino::ServiceTicket, :count).by(1)
           end
 
           it 'does set the issued_from_credentials flag on the service ticket' do
             post :create, **request_options
-            CASino::ServiceTicket.last.should be_issued_from_credentials
+            Casino::ServiceTicket.last.should be_issued_from_credentials
           end
 
           it 'generates a ticket-granting ticket' do
-            -> { post :create, **request_options }.should change(CASino::TicketGrantingTicket, :count).by(1)
+            -> { post :create, **request_options }.should change(Casino::TicketGrantingTicket, :count).by(1)
           end
         end
       end
@@ -454,7 +454,7 @@ describe CASino::SessionsController do
 
       it 'deletes the ticket-granting ticket' do
         get :logout, **request_options
-        CASino::TicketGrantingTicket.where(id: ticket_granting_ticket.id).first.should.nil?
+        Casino::TicketGrantingTicket.where(id: ticket_granting_ticket.id).first.should.nil?
       end
 
       it 'renders the logout template' do
@@ -616,12 +616,12 @@ describe CASino::SessionsController do
       let(:params) { { id: ticket_granting_ticket.id } }
 
       it 'deletes exactly one ticket-granting ticket' do
-        -> { delete :destroy, **request_options }.should change(CASino::TicketGrantingTicket, :count).by(-1)
+        -> { delete :destroy, **request_options }.should change(Casino::TicketGrantingTicket, :count).by(-1)
       end
 
       it 'deletes the ticket-granting ticket' do
         delete :destroy, **request_options
-        CASino::TicketGrantingTicket.where(id: params[:id]).length.should == 0
+        Casino::TicketGrantingTicket.where(id: params[:id]).length.should == 0
       end
 
       it 'redirects to the session overview' do
@@ -633,7 +633,7 @@ describe CASino::SessionsController do
     context 'with an invalid ticket-granting ticket' do
       let(:params) { { id: 99_999 } }
       it 'does not delete a ticket-granting ticket' do
-        -> { delete :destroy, **request_options }.should_not change(CASino::TicketGrantingTicket, :count)
+        -> { delete :destroy, **request_options }.should_not change(Casino::TicketGrantingTicket, :count)
       end
 
       it 'redirects to the session overview' do
@@ -647,7 +647,7 @@ describe CASino::SessionsController do
       let(:params) { { id: ticket_granting_ticket.id } }
 
       it 'does not delete a ticket-granting ticket' do
-        -> { delete :destroy, **request_options }.should_not change(CASino::TicketGrantingTicket, :count)
+        -> { delete :destroy, **request_options }.should_not change(Casino::TicketGrantingTicket, :count)
       end
 
       it 'redirects to the session overview' do
@@ -672,7 +672,7 @@ describe CASino::SessionsController do
       end
 
       it 'deletes all other ticket-granting tickets' do
-        -> { get :destroy_others, **request_options }.should change(CASino::TicketGrantingTicket, :count).by(-3)
+        -> { get :destroy_others, **request_options }.should change(Casino::TicketGrantingTicket, :count).by(-3)
       end
 
       it 'redirects to the session overview' do

--- a/spec/controllers/two_factor_authenticators_controller_spec.rb
+++ b/spec/controllers/two_factor_authenticators_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe CASino::TwoFactorAuthenticatorsController do
-  routes { CASino::Engine.routes }
+describe Casino::TwoFactorAuthenticatorsController do
+  routes { Casino::Engine.routes }
 
   let(:params) { Hash.new }
   let(:request_options) { {params: params} }
@@ -19,17 +19,17 @@ describe CASino::TwoFactorAuthenticatorsController do
       it 'creates exactly one authenticator' do
         lambda do
           get :new, **request_options
-        end.should change(CASino::TwoFactorAuthenticator, :count).by(1)
+        end.should change(Casino::TwoFactorAuthenticator, :count).by(1)
       end
 
       it 'assigns the two_factor_authenticator' do
         get :new, **request_options
-        assigns(:two_factor_authenticator).should be_kind_of(CASino::TwoFactorAuthenticator)
+        assigns(:two_factor_authenticator).should be_kind_of(Casino::TwoFactorAuthenticator)
       end
 
       it 'creates an inactive two-factor authenticator' do
         get :new, **request_options
-        CASino::TwoFactorAuthenticator.last.should_not be_active
+        Casino::TwoFactorAuthenticator.last.should_not be_active
       end
 
       it 'renders the new template' do
@@ -39,7 +39,7 @@ describe CASino::TwoFactorAuthenticatorsController do
 
       context 'with a really long service name' do
         before(:each) do
-          CASino.config.frontend[:sso_name] = 'Na' * 200
+          Casino.config.frontend[:sso_name] = 'Na' * 200
         end
 
         render_views
@@ -164,7 +164,7 @@ describe CASino::TwoFactorAuthenticatorsController do
 
           it 'assigns the two-factor authenticator' do
             post :create, **request_options
-            assigns(:two_factor_authenticator).should be_kind_of(CASino::TwoFactorAuthenticator)
+            assigns(:two_factor_authenticator).should be_kind_of(Casino::TwoFactorAuthenticator)
           end
 
           it 'does not activate the authenticator' do
@@ -217,7 +217,7 @@ describe CASino::TwoFactorAuthenticatorsController do
         it 'does not delete other two-factor authenticators' do
           lambda do
             delete :destroy, **request_options
-          end.should change(CASino::TwoFactorAuthenticator, :count).by(-1)
+          end.should change(Casino::TwoFactorAuthenticator, :count).by(-1)
         end
       end
 
@@ -232,7 +232,7 @@ describe CASino::TwoFactorAuthenticatorsController do
         it 'does not delete two-factor authenticators' do
           lambda do
             delete :destroy, **request_options
-          end.should_not change(CASino::TwoFactorAuthenticator, :count)
+          end.should_not change(Casino::TwoFactorAuthenticator, :count)
         end
       end
     end

--- a/spec/dummy/app/assets/stylesheets/casino_and_overrides.scss
+++ b/spec/dummy/app/assets/stylesheets/casino_and_overrides.scss
@@ -1,5 +1,5 @@
 
-// Default CASino settings
+// Default Casino settings
 
 // $buttonColor: #0074ad;
 // $buttonSecondaryColor: #c2c2c2;

--- a/spec/dummy/config/cas.yml
+++ b/spec/dummy/config/cas.yml
@@ -8,11 +8,11 @@ defaults: &defaults
     lifetime_unconsumed: 300
     lifetime_consumed: 86400
   frontend:
-    sso_name: "CASino"
-    footer_text: "Powered by <a href=\"http://rbcas.com/\">CASino</a>"
+    sso_name: "Casino"
+    footer_text: "Powered by <a href=\"http://rbcas.com/\">Casino</a>"
   authenticators:
     static:
-      class: "CASino::StaticAuthenticator"
+      class: "Casino::StaticAuthenticator"
       options:
         users:
           testuser:

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  mount CASino::Engine => '/', :as => 'casino'
+  mount Casino::Engine => '/', :as => 'casino'
 end

--- a/spec/dummy/db/migrate/20140831214845_create_core_schema.casino.rb
+++ b/spec/dummy/db/migrate/20140831214845_create_core_schema.casino.rb
@@ -1,6 +1,6 @@
 # This migration comes from casino (originally 20130809135400)
-# In order to support pre-2.0 installations of CASino that included CASinoCore,
-# we must rebuild the un-namespaced CASinoCore schema so that we can upgrade
+# In order to support pre-2.0 installations of Casino that included CasinoCore,
+# we must rebuild the un-namespaced CasinoCore schema so that we can upgrade
 class CreateCoreSchema < ActiveRecord::Migration
   CoreTables = %w{login_tickets proxy_granting_tickets proxy_tickets service_rules service_tickets ticket_granting_tickets two_factor_authenticators users}
 

--- a/spec/dummy/db/migrate/20140831214847_cleanup_indexes.casino.rb
+++ b/spec/dummy/db/migrate/20140831214847_cleanup_indexes.casino.rb
@@ -1,7 +1,7 @@
 # This migration comes from casino (originally 20131022110146)
 class CleanupIndexes < ActiveRecord::Migration
   def change
-    # delete some leftovers in migrated CASino 1.x installations
+    # delete some leftovers in migrated Casino 1.x installations
     remove_deprecated_index_if_exists :login_tickets, [:ticket]
     remove_deprecated_index_if_exists :proxy_granting_tickets, [:granter_type, :granter_id]
     remove_deprecated_index_if_exists :proxy_granting_tickets, [:iou]

--- a/spec/features/login_attempts_spec.rb
+++ b/spec/features/login_attempts_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe 'Session overview' do
-  include CASino::Engine.routes.url_helpers
+  include Casino::Engine.routes.url_helpers
 
   subject { page }
 
   context 'when logged in' do
     let(:login_attempt) do
       FactoryBot.create :login_attempt, created_at: Time.zone.parse('2015-01-01 09:10'),
-                                         user: CASino::User.first
+                                         user: Casino::User.first
     end
 
     before do

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Login' do
-  include CASino::Engine.routes.url_helpers
+  include Casino::Engine.routes.url_helpers
 
   subject { page }
 

--- a/spec/features/logout_spec.rb
+++ b/spec/features/logout_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Logout' do
-  include CASino::Engine.routes.url_helpers
+  include Casino::Engine.routes.url_helpers
 
   subject { page }
 

--- a/spec/features/session_overview_spec.rb
+++ b/spec/features/session_overview_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe 'Session overview' do
-  include CASino::Engine.routes.url_helpers
+  include Casino::Engine.routes.url_helpers
 
   subject { page }
 
   context 'when logged in' do
     let(:login_attempt) do
       FactoryBot.create :login_attempt, created_at: Time.zone.parse('2015-01-01 09:10'),
-                                         user: CASino::User.first
+                                         user: Casino::User.first
     end
 
     before do

--- a/spec/features/two_factor_authenticator_spec.rb
+++ b/spec/features/two_factor_authenticator_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'TwoFactorAuthenticator' do
-  include CASino::Engine.routes.url_helpers
+  include Casino::Engine.routes.url_helpers
 
   subject { page }
 
@@ -23,7 +23,7 @@ describe 'TwoFactorAuthenticator' do
         it { should have_text 'authenticator was successfully deleted' }
 
         it 'deletes the two-factor authenticator' do
-          CASino::TwoFactorAuthenticator.count.should == 0
+          Casino::TwoFactorAuthenticator.count.should == 0
         end
       end
     end

--- a/spec/model/auth_token_ticket_spec.rb
+++ b/spec/model/auth_token_ticket_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CASino::AuthTokenTicket do
+describe Casino::AuthTokenTicket do
   describe '.cleanup' do
     it 'deletes expired auth token tickets' do
       ticket = described_class.new ticket: 'ATT-12345'

--- a/spec/model/login_attempt_spec.rb
+++ b/spec/model/login_attempt_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CASino::LoginAttempt do
+describe Casino::LoginAttempt do
   subject { described_class.new user_agent: 'TestBrowser' }
 
   it_behaves_like 'has browser info'

--- a/spec/model/login_ticket_spec.rb
+++ b/spec/model/login_ticket_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CASino::LoginTicket do
+describe Casino::LoginTicket do
   describe '.cleanup' do
     it 'deletes expired login tickets' do
       ticket = described_class.new ticket: 'LT-12345'

--- a/spec/model/proxy_ticket_spec.rb
+++ b/spec/model/proxy_ticket_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CASino::ProxyTicket do
+describe Casino::ProxyTicket do
   let(:unconsumed_ticket) do
     ticket = described_class.new ticket: 'PT-12345', service: 'any_string_is_valid'
     ticket.proxy_granting_ticket_id = 1
@@ -21,7 +21,7 @@ describe CASino::ProxyTicket do
 
         context 'with an expired ticket' do
           before(:each) do
-            ticket.created_at = (CASino.config.service_ticket[:"lifetime_#{state}"].seconds + 1).ago
+            ticket.created_at = (Casino.config.service_ticket[:"lifetime_#{state}"].seconds + 1).ago
             ticket.save!
           end
 

--- a/spec/model/service_rule_spec.rb
+++ b/spec/model/service_rule_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CASino::ServiceRule do
+describe Casino::ServiceRule do
   describe '.allowed?' do
     context 'with an empty table' do
       context 'with default settings' do
@@ -13,7 +13,7 @@ describe CASino::ServiceRule do
 
       context 'with require_service_rules option' do
         before(:each) do
-          CASino.config.require_service_rules = true
+          Casino.config.require_service_rules = true
         end
 
         ['https://www.example.org/', 'http://www.google.com/'].each do |service_url|

--- a/spec/model/service_ticket/single_sign_out_notifier_spec.rb
+++ b/spec/model/service_ticket/single_sign_out_notifier_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'nokogiri'
 
-describe CASino::ServiceTicket::SingleSignOutNotifier do
+describe Casino::ServiceTicket::SingleSignOutNotifier do
   let(:service_ticket) { FactoryBot.create :service_ticket }
   let(:service) { service_ticket.service }
   let(:notifier) { described_class.new service_ticket }
@@ -23,7 +23,7 @@ describe CASino::ServiceTicket::SingleSignOutNotifier do
 
     it 'sets the timeout values' do
       %i[read_timeout= open_timeout=].each do |timeout|
-        Net::HTTP.any_instance.should_receive(timeout).with(CASino.config.service_ticket[:single_sign_out_notification][:timeout])
+        Net::HTTP.any_instance.should_receive(timeout).with(Casino.config.service_ticket[:single_sign_out_notification][:timeout])
       end
       notifier.notify
     end

--- a/spec/model/service_ticket_spec.rb
+++ b/spec/model/service_ticket_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CASino::ServiceTicket do
+describe Casino::ServiceTicket do
   let(:unconsumed_ticket) do
     ticket = described_class.new ticket: 'ST-12345', service: 'https://example.com/cas-service'
     ticket.ticket_granting_ticket_id = 1
@@ -21,7 +21,7 @@ describe CASino::ServiceTicket do
 
         context 'with an expired ticket' do
           before(:each) do
-            ticket.created_at = (CASino.config.service_ticket[:"lifetime_#{state}"].seconds + 1).ago
+            ticket.created_at = (Casino.config.service_ticket[:"lifetime_#{state}"].seconds + 1).ago
             ticket.save!
           end
 
@@ -110,7 +110,7 @@ describe CASino::ServiceTicket do
         consumed_ticket
         lambda {
           consumed_ticket.destroy
-        }.should change(CASino::ServiceTicket, :count).by(-1)
+        }.should change(Casino::ServiceTicket, :count).by(-1)
       end
     end
   end

--- a/spec/model/ticket_granting_ticket_spec.rb
+++ b/spec/model/ticket_granting_ticket_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'useragent'
 
-describe CASino::TicketGrantingTicket do
+describe Casino::TicketGrantingTicket do
   let(:ticket_granting_ticket) { FactoryBot.create :ticket_granting_ticket, user_agent: 'TestBrowser' }
   let(:service_ticket) { FactoryBot.create :service_ticket, ticket_granting_ticket: ticket_granting_ticket }
 
@@ -14,20 +14,20 @@ describe CASino::TicketGrantingTicket do
 
     context 'when notification for a service ticket fails' do
       before(:each) do
-        CASino::ServiceTicket::SingleSignOutNotifier.any_instance.stub(:notify).and_return(false)
+        Casino::ServiceTicket::SingleSignOutNotifier.any_instance.stub(:notify).and_return(false)
       end
 
       it 'deletes depending proxy-granting tickets' do
         consumed_service_ticket.proxy_granting_tickets.create! ticket: 'PGT-12345', iou: 'PGTIOU-12345', pgt_url: 'bla'
         lambda {
           ticket_granting_ticket.destroy
-        }.should change(CASino::ProxyGrantingTicket, :count).by(-1)
+        }.should change(Casino::ProxyGrantingTicket, :count).by(-1)
       end
 
       it 'deletes depending service tickets' do
         lambda {
           ticket_granting_ticket.destroy
-        }.should change(CASino::ServiceTicket, :count).by(-1)
+        }.should change(Casino::ServiceTicket, :count).by(-1)
       end
     end
   end

--- a/spec/model/two_factor_authenticator_spec.rb
+++ b/spec/model/two_factor_authenticator_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CASino::TwoFactorAuthenticator do
+describe Casino::TwoFactorAuthenticator do
   describe '.cleanup' do
     it 'deletes expired inactive two-factor authenticators' do
       authenticator = FactoryBot.create :two_factor_authenticator, :inactive
@@ -13,7 +13,7 @@ describe CASino::TwoFactorAuthenticator do
 
     it 'does not delete not expired inactive two-factor authenticators' do
       authenticator = FactoryBot.create :two_factor_authenticator, :inactive
-      authenticator.created_at = (CASino.config.two_factor_authenticator[:lifetime_inactive].seconds - 5).ago
+      authenticator.created_at = (Casino.config.two_factor_authenticator[:lifetime_inactive].seconds - 5).ago
       lambda do
         described_class.cleanup
       end.should_not change(described_class, :count)

--- a/spec/services/auth_token_validation_service_spec.rb
+++ b/spec/services/auth_token_validation_service_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CASino::AuthTokenValidationService do
+describe Casino::AuthTokenValidationService do
   let(:token) { 'le_token' }
   let(:signature) { 'le_signature' }
 
@@ -8,7 +8,7 @@ describe CASino::AuthTokenValidationService do
 
   context 'without any token signers' do
     before(:each) do
-      Dir.stub(:glob).with(CASino::AuthTokenValidationService::AUTH_TOKEN_SIGNERS_GLOB).and_return(nil)
+      Dir.stub(:glob).with(Casino::AuthTokenValidationService::AUTH_TOKEN_SIGNERS_GLOB).and_return(nil)
     end
 
     its(:user_data) { should == nil }
@@ -26,7 +26,7 @@ describe CASino::AuthTokenValidationService do
     end
 
     before(:each) do
-      Dir.stub(:glob).with(CASino::AuthTokenValidationService::AUTH_TOKEN_SIGNERS_GLOB) do |&block|
+      Dir.stub(:glob).with(Casino::AuthTokenValidationService::AUTH_TOKEN_SIGNERS_GLOB) do |&block|
         block.call(signer_path)
       end
       File.stub(:read).with(signer_path).and_return(signer_path_content)
@@ -45,7 +45,7 @@ describe CASino::AuthTokenValidationService do
       let(:signature_valid) { true }
 
       before(:each) do
-        CASino::AuthTokenTicket.stub(:consume).and_return(ticket_valid)
+        Casino::AuthTokenTicket.stub(:consume).and_return(ticket_valid)
       end
 
       context 'with an invalid ticket' do

--- a/spec/support/casino.rb
+++ b/spec/support/casino.rb
@@ -2,11 +2,11 @@ require 'active_support/core_ext/object/deep_dup'
 
 RSpec.configure do |config|
   config.before do
-    @base_config = CASino.config.deep_dup
+    @base_config = Casino.config.deep_dup
   end
 
   config.after do
-    CASino.config.clear
-    CASino.config.merge! @base_config
+    Casino.config.clear
+    Casino.config.merge! @base_config
   end
 end

--- a/spec/support/factories/login_attempt_factory.rb
+++ b/spec/support/factories/login_attempt_factory.rb
@@ -1,7 +1,7 @@
 require 'factory_girl'
 
 FactoryBot.define do
-  factory :login_attempt, class: CASino::LoginAttempt do
+  factory :login_attempt, class: Casino::LoginAttempt do
     user
     successful true
     user_ip '133.133.133.133'

--- a/spec/support/factories/login_ticket_factory.rb
+++ b/spec/support/factories/login_ticket_factory.rb
@@ -1,7 +1,7 @@
 require 'factory_girl'
 
 FactoryBot.define do
-  factory :login_ticket, class: CASino::LoginTicket do
+  factory :login_ticket, class: Casino::LoginTicket do
     sequence :ticket do |n|
       "LT-ticket#{n}"
     end

--- a/spec/support/factories/proxy_granting_ticket_factory.rb
+++ b/spec/support/factories/proxy_granting_ticket_factory.rb
@@ -1,7 +1,7 @@
 require 'factory_girl'
 
 FactoryBot.define do
-  factory :proxy_granting_ticket, class: CASino::ProxyGrantingTicket do
+  factory :proxy_granting_ticket, class: Casino::ProxyGrantingTicket do
     association :granter, factory: :service_ticket
     sequence :ticket do |n|
       "PGT-ticket#{n}"

--- a/spec/support/factories/proxy_ticket_factory.rb
+++ b/spec/support/factories/proxy_ticket_factory.rb
@@ -1,7 +1,7 @@
 require 'factory_girl'
 
 FactoryBot.define do
-  factory :proxy_ticket, class: CASino::ProxyTicket do
+  factory :proxy_ticket, class: Casino::ProxyTicket do
     proxy_granting_ticket
     sequence :ticket do |n|
       "PT-ticket#{n}"

--- a/spec/support/factories/service_rule_factory.rb
+++ b/spec/support/factories/service_rule_factory.rb
@@ -1,7 +1,7 @@
 require 'factory_girl'
 
 FactoryBot.define do
-  factory :service_rule, class: CASino::ServiceRule do
+  factory :service_rule, class: Casino::ServiceRule do
     sequence :order do |n|
       n
     end

--- a/spec/support/factories/service_ticket_factory.rb
+++ b/spec/support/factories/service_ticket_factory.rb
@@ -1,7 +1,7 @@
 require 'factory_girl'
 
 FactoryBot.define do
-  factory :service_ticket, class: CASino::ServiceTicket do
+  factory :service_ticket, class: Casino::ServiceTicket do
     ticket_granting_ticket
     sequence :ticket do |n|
       "ST-ticket#{n}"

--- a/spec/support/factories/ticket_granting_ticket_factory.rb
+++ b/spec/support/factories/ticket_granting_ticket_factory.rb
@@ -1,7 +1,7 @@
 require 'factory_girl'
 
 FactoryBot.define do
-  factory :ticket_granting_ticket, class: CASino::TicketGrantingTicket do
+  factory :ticket_granting_ticket, class: Casino::TicketGrantingTicket do
     user
     sequence :ticket do |n|
       "TGC-ticket#{n}"

--- a/spec/support/factories/two_factor_authenticator_factory.rb
+++ b/spec/support/factories/two_factor_authenticator_factory.rb
@@ -2,7 +2,7 @@ require 'factory_girl'
 require 'rotp'
 
 FactoryBot.define do
-  factory :two_factor_authenticator, class: CASino::TwoFactorAuthenticator do
+  factory :two_factor_authenticator, class: Casino::TwoFactorAuthenticator do
     user
     secret do
       ROTP::Base32.random_base32

--- a/spec/support/factories/user_factory.rb
+++ b/spec/support/factories/user_factory.rb
@@ -1,7 +1,7 @@
 require 'factory_girl'
 
 FactoryBot.define do
-  factory :user, class: CASino::User do
+  factory :user, class: Casino::User do
     authenticator 'test'
     sequence(:username) do |n|
       "test#{n}"


### PR DESCRIPTION
We need ruby >3 to be able to upgrade TASN-SSO to Rails 8.0.0

It seems the main changes needed are to drop the `CASino` syntax in lieu of `Casino` as well as drop `::API` to ::`Api`.

There are a few runtime dependencies I bumped as well.

Running TASN-SSO on rails 8 locally while pointed at this branch is working as expected.

Original [PR Found Here](https://github.com/kipusystems/CASino/pull/1)